### PR TITLE
Updated to v16.00

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = 'psqlODBC' %}
-{% set version = "13.01" %}
+{% set version = "16.00" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: 'https://ftp.postgresql.org/pub/odbc/versions/src/psqlodbc-{{ version }}.0000.tar.gz'
-  sha256: 435de2ea38109b8384ed76d327032b73a53a915379a752a34b0f9c7539055da7
+  url: https://ftp.postgresql.org/pub/odbc/versions.old/src/psqlodbc-{{ version }}.0000.tar.gz
+  sha256: afd892f89d2ecee8d3f3b2314f1bd5bf2d02201872c6e3431e5c31096eca4c8b
 
 build:
   number: 0
@@ -16,18 +16,20 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - python >=3.6
-    - make   # [not win]
+    - python
     - m2-make   # [win]
+    - make      # [not win]
     - libtool   # [not win]
   host:
-    - unixodbc
-    - postgresql
+    - unixodbc 2.3.11
+    - libpq 17.0
   run:
     - unixodbc
     - libpq
 
 test:
+  requires:
+    - conda-build
   commands:
     - conda inspect linkages psqlodbc
     # This is using .so on both osx and linux
@@ -40,6 +42,8 @@ about:
   license_family: GPL
   license_file: license.txt
   summary: psqlODBC is the official PostgreSQL ODBC Driver
+  description: |
+    A library to talk to the PostgreSQL DBMS using ODBC.
   doc_url: https://odbc.postgresql.org/
   dev_url: https://git.postgresql.org/gitweb/?p=psqlodbc.git
 


### PR DESCRIPTION
psqlodbc 16.00

**Destination channel:** defaults

### Links

- [PKG-6105](https://anaconda.atlassian.net/browse/PKG-6105)
- [Upstream repository](https://git.postgresql.org/gitweb/?p=psqlodbc.git)
- Relevant dependency PRs:
  - AnacondaRecipes/postgresql-feedstock#10

### Explanation of changes:

- Added proper host pinnings
- Added required metadata


[PKG-6105]: https://anaconda.atlassian.net/browse/PKG-6105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ