### PR TITLE
rebuild psqlodbc against libpq 18.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - libtool
   host:
     - unixodbc 2.3.11
-    - postgresql 17.6
+    - postgresql 18.4
     - libpq 18.4  # TODO: change back to the libpq jinja placeholder once the global libpq pin in the aggregate's conda_build_config.yaml is bumped to 18.4
   run:
     - unixodbc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: cf15619e7fcc31ce3f61634243ca9fbb1e1c7dfdac19d7bda2a66483c029d4b5
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
 requirements:
@@ -25,7 +25,7 @@ requirements:
   host:
     - unixodbc 2.3.11
     - postgresql 17.6
-    - libpq {{ libpq }}
+    - libpq 18.4  # TODO: change back to the libpq jinja placeholder once the global libpq pin in the aggregate's conda_build_config.yaml is bumped to 18.4
   run:
     - unixodbc
     - libpq


### PR DESCRIPTION
## Rebuild psqlodbc against libpq 18.4

### Links
- Jira Ticket: [PKG-15956](https://anaconda.atlassian.net/browse/PKG-15956)
- Dev URL: [github.com/postgresql-interfaces/psqlodbc](https://github.com/postgresql-interfaces/psqlodbc)

### Changes
- `recipe/meta.yaml`: bump build number to 1; pin the `libpq` host requirement to `18.4` (with a TODO to revert to the `{{ libpq }}` placeholder once the global pin is bumped)

[PKG-15956]: https://anaconda.atlassian.net/browse/PKG-15956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ